### PR TITLE
Change models from `GPT35Turbo` to `GPT4oMini`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ ___
 
   The SimpleSend method will send the specified text to ChatGPT and return a response. If an error occurs, an error message will be returned.
 
-4. To use a model and/or parameters, use the `Send` API. For example, the following uses the gpt-3.5-turbo (`GPT35Turbo`) model.
+4. To use a model and/or parameters, use the `Send` API. For example, the following uses the gpt-4o-mini (`GPT4oMini`) model.
 
   ```go
   ctx := context.Background()
 
   res, err = c.Send(ctx, &chatgpt.ChatCompletionRequest{
-    Model: chatgpt.GPT35Turbo,
+    Model: chatgpt.GPT4oMini,
     Messages: []chatgpt.ChatMessage{
       {
         Role: chatgpt.ChatGPTModelRoleSystem,

--- a/chat.go
+++ b/chat.go
@@ -99,7 +99,7 @@ type ChatResponseUsage struct {
 
 func (c *Client) SimpleSend(ctx context.Context, message string) (*ChatResponse, error) {
 	req := &ChatCompletionRequest{
-		Model: GPT35Turbo,
+		Model: GPT4oMini,
 		Messages: []ChatMessage{
 			{
 				Role:    ChatGPTModelRoleUser,

--- a/chat_test.go
+++ b/chat_test.go
@@ -37,7 +37,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "Invalid role",
 			request: &ChatCompletionRequest{
-				Model: GPT35Turbo,
+				Model: GPT4oMini,
 				Messages: []ChatMessage{
 					{
 						Role:    "invalid-role",
@@ -50,7 +50,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "Invalid temperature",
 			request: &ChatCompletionRequest{
-				Model:       GPT35Turbo,
+				Model:       GPT4oMini,
 				Messages:    validRequest().Messages,
 				Temperature: -0.5,
 			},
@@ -59,7 +59,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "Invalid presence penalty",
 			request: &ChatCompletionRequest{
-				Model:           GPT35Turbo,
+				Model:           GPT4oMini,
 				Messages:        validRequest().Messages,
 				PresencePenalty: -3,
 			},
@@ -68,7 +68,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "Invalid frequency penalty",
 			request: &ChatCompletionRequest{
-				Model:            GPT35Turbo,
+				Model:            GPT4oMini,
 				Messages:         validRequest().Messages,
 				FrequencyPenalty: -3,
 			},
@@ -86,7 +86,7 @@ func TestValidate(t *testing.T) {
 
 func validRequest() *ChatCompletionRequest {
 	return &ChatCompletionRequest{
-		Model: GPT35Turbo,
+		Model: GPT4oMini,
 		Messages: []ChatMessage{
 			{
 				Role:    ChatGPTModelRoleUser,
@@ -155,7 +155,7 @@ func TestSend(t *testing.T) {
 	defer server.Close()
 
 	_, err := client.Send(context.Background(), &ChatCompletionRequest{
-		Model: GPT35Turbo,
+		Model: GPT4oMini,
 		Messages: []ChatMessage{
 			{
 				Role:    ChatGPTModelRoleUser,
@@ -180,7 +180,7 @@ func TestSend(t *testing.T) {
 	defer server.Close()
 
 	_, err = client.Send(context.Background(), &ChatCompletionRequest{
-		Model: GPT35Turbo,
+		Model: GPT4oMini,
 		Messages: []ChatMessage{
 			{
 				Role:    ChatGPTModelRoleUser,
@@ -194,7 +194,7 @@ func TestSend(t *testing.T) {
 	defer server.Close()
 
 	_, err = client.Send(context.Background(), &ChatCompletionRequest{
-		Model: GPT35Turbo,
+		Model: GPT4oMini,
 		Messages: []ChatMessage{
 			{
 				Role:    ChatGPTModelRoleUser,


### PR DESCRIPTION
This PR changes default models from `GPT35Turbo` to `GPT4oMini`.