### PR TITLE
Add OpenAI o1-preview and o1-mini models

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Go-ChatGPT is an open-source GoLang client for ChatGPT, a large language model t
 
 - Provides a GoLang client for ChatGPT.
 - Sends text to ChatGPT and receives a response from ChatGPT.
-- Supports GPT3.5 and GPT4 models.
+- Supports GPT4, GPT4o, GPT3.5, and o1 models.
 
 ## Installation
 

--- a/chat.go
+++ b/chat.go
@@ -12,13 +12,15 @@ import (
 type ChatGPTModel string
 
 const (
-	// gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4, and gpt-3.5-turbo point to their respective latest model version. 
+	// The models listed below point to their respective latest model version. 
 	// For details about models, see https://platform.openai.com/docs/models.
 	GPT4o             ChatGPTModel = "gpt-4o"
 	GPT4oMini         ChatGPTModel = "gpt-4o-mini"
 	GPT4Turbo         ChatGPTModel = "gpt-4-turbo"
 	GPT4              ChatGPTModel = "gpt-4"
 	GPT35Turbo        ChatGPTModel = "gpt-3.5-turbo"
+	o1Preview         ChatGPTModel = "o1-preview"
+	o1Mini            ChatGPTModel = "o1-mini"
 )
 
 type ChatGPTModelRole string
@@ -147,7 +149,7 @@ func validate(req *ChatCompletionRequest) error {
 	isAllowed := false
 
 	allowedModels := []ChatGPTModel{
-		GPT4o, GPT4oMini, GPT4Turbo, GPT4, GPT35Turbo,
+		GPT4o, GPT4oMini, GPT4Turbo, GPT4, GPT35Turbo, o1Preview, o1Mini,
 	}
 
 	for _, model := range allowedModels {


### PR DESCRIPTION
## Description

This PR adds recently released OpenAI models `o1-preview` and `o1-mini`. For details about these models, see [Introducing OpenAI o1-preview](https://openai.com/index/introducing-openai-o1-preview/).

## Related issues and/or PRs

N/A

## Changes made

- Added `o1-preview` and `o1-mini` to the list of models.
- Mentioned the new model type in the README.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings.
