### PR TITLE
Change `o1-preview` to `o1`

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -19,7 +19,7 @@ const (
 	GPT4Turbo         ChatGPTModel = "gpt-4-turbo"
 	GPT4              ChatGPTModel = "gpt-4"
 	GPT35Turbo        ChatGPTModel = "gpt-3.5-turbo"
-	o1Preview         ChatGPTModel = "o1-preview"
+	o1                ChatGPTModel = "o1"
 	o1Mini            ChatGPTModel = "o1-mini"
 )
 
@@ -149,7 +149,7 @@ func validate(req *ChatCompletionRequest) error {
 	isAllowed := false
 
 	allowedModels := []ChatGPTModel{
-		GPT4o, GPT4oMini, GPT4Turbo, GPT4, GPT35Turbo, o1Preview, o1Mini,
+		GPT4o, GPT4oMini, GPT4Turbo, GPT4, GPT35Turbo, o1, o1Mini,
 	}
 
 	for _, model := range allowedModels {


### PR DESCRIPTION
## Description

This PR updates the naming for the OpenAI o1 model. Since o1 is out of preview, this model can be changed to use the non-preview model.

## Related issues and/or PRs

N/A

## Changes made

- Changed the model from `o1-preview` to `o1`.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings.
