### PR TITLE
Remove `gpt-3.5-turbo` from supported-models list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Go-ChatGPT
 
-Go-ChatGPT is an open-source GoLang client for ChatGPT, a large language model trained by OpenAI. With Go-ChatGPT, you can integrate ChatGPT's language processing capabilities into your Go applications.
+Go-ChatGPT is an open-source GoLang client for OpenAI's large language models (LLMs). By using this client, you can integrate the language-processing capabilities of OpenAI's LLMs into your Go-based applications.
 
 ## Features
 
-- Provides a GoLang client for ChatGPT.
-- Sends text to ChatGPT and receives a response from ChatGPT.
-- Supports GPT4, GPT4o, and o1 models.
+- Provides a GoLang client for OpenAI's LLMs.
+- Supports OpenAI's GPT-4o, GPT-4o mini, GPT-4, GPT-4 Turbo, o1, and o1-mini models.
+- Sends text to OpenAI and receives a response from the LLM that you chose.
 
 ## Installation
 
@@ -45,7 +45,7 @@ ___
   }
   ```
 
-3. Use the `SimpleSend` API to send text to ChatGPT and get a response.
+3. Use the `SimpleSend` API to send text to OpenAI and get a response.
 
   ```go
   ctx := context.Background()
@@ -56,7 +56,7 @@ ___
   }
   ```
 
-  The SimpleSend method will send the specified text to ChatGPT and return a response. If an error occurs, an error message will be returned.
+  The SimpleSend method will send the specified text to OpenAI and return a response. If an error occurs, an error message will be returned.
 
 4. To use a model and/or parameters, use the `Send` API. For example, the following uses the gpt-4o-mini (`GPT4oMini`) model.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Go-ChatGPT is an open-source GoLang client for ChatGPT, a large language model t
 
 - Provides a GoLang client for ChatGPT.
 - Sends text to ChatGPT and receives a response from ChatGPT.
-- Supports GPT4, GPT4o, GPT3.5, and o1 models.
+- Supports GPT4, GPT4o, and o1 models.
 
 ## Installation
 

--- a/chat.go
+++ b/chat.go
@@ -18,7 +18,6 @@ const (
 	GPT4oMini         ChatGPTModel = "gpt-4o-mini"
 	GPT4Turbo         ChatGPTModel = "gpt-4-turbo"
 	GPT4              ChatGPTModel = "gpt-4"
-	GPT35Turbo        ChatGPTModel = "gpt-3.5-turbo"
 	o1Preview         ChatGPTModel = "o1-preview"
 	o1Mini            ChatGPTModel = "o1-mini"
 )
@@ -149,7 +148,7 @@ func validate(req *ChatCompletionRequest) error {
 	isAllowed := false
 
 	allowedModels := []ChatGPTModel{
-		GPT4o, GPT4oMini, GPT4Turbo, GPT4, GPT35Turbo, o1Preview, o1Mini,
+		GPT4o, GPT4oMini, GPT4Turbo, GPT4, o1Preview, o1Mini,
 	}
 
 	for _, model := range allowedModels {


### PR DESCRIPTION
## Description

This PR removes gpt-3.5-turbo as a selectable model. OpenAI recommends using gpt-4o instead of gpt-3.5-turbo, so I don't see the need to maintain it anymore.

This PR also revises the README for clarity.

## Related issues and/or PRs

- Some changes in #8 will affect the merging of this PR.

## Changes made

- Removed gpt-3.5-turbo from the source code.
- Removed gpt-3.5-turbo from the README.
- Revised the README for clarity.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings.
