### PR TITLE
Add OpenAI o3-mini model

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Go-ChatGPT is an open-source GoLang client for OpenAI's large language models (L
   - **Reasoning models:**
     - o1
     - o1-mini
+    - o3-mini
 - Sends text to OpenAI and receives a response from the LLM that you chose.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@ Go-ChatGPT is an open-source GoLang client for OpenAI's large language models (L
 ## Features
 
 - Provides a GoLang client for OpenAI's LLMs.
-- Supports OpenAI's GPT-4o, GPT-4o mini, GPT-4, GPT-4 Turbo, o1, and o1-mini models.
+- Supports the following OpenAI models:
+  - **GPT models:**
+    - GPT-4o
+    - GPT-4o mini
+    - GPT-4
+    - GPT-4 Turbo
+  - **Reasoning models:**
+    - o1
+    - o1-mini
 - Sends text to OpenAI and receives a response from the LLM that you chose.
 
 ## Installation

--- a/chat.go
+++ b/chat.go
@@ -20,6 +20,7 @@ const (
 	GPT4              ChatGPTModel = "gpt-4"
 	o1                ChatGPTModel = "o1"
 	o1Mini            ChatGPTModel = "o1-mini"
+	o3Mini						ChatGPTModel = "o3-mini"
 )
 
 type ChatGPTModelRole string
@@ -148,7 +149,7 @@ func validate(req *ChatCompletionRequest) error {
 	isAllowed := false
 
 	allowedModels := []ChatGPTModel{
-		GPT4o, GPT4oMini, GPT4Turbo, GPT4, o1, o1Mini,
+		GPT4o, GPT4oMini, GPT4Turbo, GPT4, o1, o1Mini, o3Mini,
 	}
 
 	for _, model := range allowedModels {


### PR DESCRIPTION
## Description

This PR adds recently released OpenAI models o1-preview and o1-mini. For details about these models, see [OpenAI o3-mini](https://openai.com/index/openai-o3-mini/).

## Related issues and/or PRs

N/A

## Changes made

- Added o3-mini to the list of `allowedModels`.
- In the README:
  - Added o3-mini to the list.
  - Separated the list of LLMs by GPT models and reasoning models.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary.
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
