### PR TITLE
Fix formatting between internal and official model names

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -20,7 +20,7 @@ const (
 	GPT4              ChatGPTModel = "gpt-4"
 	o1                ChatGPTModel = "o1"
 	o1Mini            ChatGPTModel = "o1-mini"
-	o3Mini						ChatGPTModel = "o3-mini"
+	o3Mini            ChatGPTModel = "o3-mini"
 )
 
 type ChatGPTModelRole string


### PR DESCRIPTION
## Description

This PR fixes some awkward formatting between the internal model name and the official model names for o3-mini, which was introduced in #12. I don't think this causes an issue with running o3-mini, but just in case, it's better to fix it now than to wonder why things aren't working later.

## Related issues and/or PRs

- #12

## Changes made

- Changed the tabs to spaces between the `o3Mini`, which is the internal model name, and `o3-mini`, which is the official model name.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary.
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
